### PR TITLE
fixed `Something went wrong while fetching the access token`

### DIFF
--- a/src/LaravelFacebookAds/Services/FacebookAdsService.php
+++ b/src/LaravelFacebookAds/Services/FacebookAdsService.php
@@ -225,11 +225,11 @@ class FacebookAdsService implements FacebookAdsServiceInterface
             )
         );
 
-        if (!substr_count($token, 'access_token=')) {
+        if (!substr_count($token, 'access_token')) {
             return false;
         }
 
-        $token = str_replace('access_token=', '', $token);
+        $token = str_replace('"access_token":', '', $token);
 
         return $token;
     }


### PR DESCRIPTION
There is a change from facbook, when they sent the token back it does not contain '=' as expected in exisitng code, due to that it triggers `Something went wrong while fetching the access token` error!